### PR TITLE
Support riot 9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,23 +19,11 @@
         "jsdom": "^20.0.0",
         "jsdom-global": "3.0.2",
         "mocha": "^8.4.0",
-        "riot": "^7.0.3",
+        "riot": "^9.0.4",
         "rollup": "^2.78.0"
       },
       "peerDependencies": {
-        "riot": "^6.0.0 || ^7.0.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.18.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
-      "integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+        "riot": "^6.0.0 || ^7.0.0 || ^9.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -134,62 +122,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@riotjs/compiler": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@riotjs/compiler/-/compiler-6.3.2.tgz",
-      "integrity": "sha512-pGlLt08lhYeK+KMD3sPKsXInjQQWx9qMb7A/DPqbfMUvplsoTHnF2QfBWSmENqCaKGPGC4pTM1YCnaghQ5W6PA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.18.10",
-        "@riotjs/parser": "^4.3.1",
-        "@riotjs/util": "2.1.1",
-        "cssesc": "^3.0.0",
-        "cumpa": "^1.0.1",
-        "curri": "^1.0.1",
-        "dom-nodes": "^1.1.3",
-        "globals": "^13.17.0",
-        "recast": "^0.20.5",
-        "source-map": "^0.7.4"
-      }
-    },
-    "node_modules/@riotjs/compiler/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@riotjs/dom-bindings": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@riotjs/dom-bindings/-/dom-bindings-6.0.4.tgz",
-      "integrity": "sha512-7KZh9dG8COmrW63xa27iAvN3Q0aJN3ACbXTg7YCuTtD2DGHdn1SmSheCYGn03pJUzsm1pdjS/mU4BFZ2tJQklQ==",
-      "dev": true,
-      "dependencies": {
-        "@riotjs/util": "^2.1.1"
-      }
-    },
-    "node_modules/@riotjs/parser": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@riotjs/parser/-/parser-4.3.1.tgz",
-      "integrity": "sha512-ZUeAcey3ShAtquHBwuHFLrtPL1j0iEeXoOQoaZMaqVp15vq5UqOBxBcOVNfCXbr9ZbhnVCEEmek/9YFt5Ni8bA==",
-      "dev": true,
-      "dependencies": {
-        "curri": "^1.0.1",
-        "dom-nodes": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=4.2",
-        "npm": ">=3.0"
-      }
-    },
-    "node_modules/@riotjs/util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@riotjs/util/-/util-2.1.1.tgz",
-      "integrity": "sha512-uE3yhckx6QhFESlA/jO/Nj8HcOeRiCV3Zw1OrdKiRAMh4o/JBhGuAkoknPWCDTHSFIffHuWV8EorbO1wZLBpvw==",
-      "dev": true
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -350,18 +282,6 @@
         "node": "*"
       }
     },
-    "node_modules/ast-types": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
-      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -373,15 +293,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "node_modules/bianco.attr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bianco.attr/-/bianco.attr-1.1.1.tgz",
-      "integrity": "sha512-fTjfPnnGYiCVbe5UltC/LsDRtJE+MjmadtL749CMIfCwjl18sdbCkaQ7cgtSao6iC9ZJC8Pzw0rjMdIuA6mK1g==",
-      "dev": true,
-      "dependencies": {
-        "bianco.dom-to-array": "^1.1.0"
-      }
     },
     "node_modules/bianco.dom-to-array": {
       "version": "1.1.0",
@@ -606,18 +517,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -640,18 +539,6 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "dev": true
-    },
-    "node_modules/cumpa": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cumpa/-/cumpa-1.0.1.tgz",
-      "integrity": "sha512-Ew3sfG4cqvDFINS1VgdvLX1FIruhySlnP6DRLhB+1EjewiOzhJzKRKPEp/TCuo0RDisSFeuaDrk0S4Q8grF9CA==",
-      "dev": true
-    },
-    "node_modules/curri": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/curri/-/curri-1.0.1.tgz",
-      "integrity": "sha512-VwFb2MGqN0A1RPA0vSgDRSWc0c+V6N9yz8pVYJ9AXILAukRAyCZP5Sqp4VdOxgw1lT0t5oaplwIDT/ruF3Nz7Q==",
       "dev": true
     },
     "node_modules/data-urls": {
@@ -750,12 +637,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/dom-nodes": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dom-nodes/-/dom-nodes-1.1.3.tgz",
-      "integrity": "sha512-y5wnIx97oe0IqMllL/lizgkK2c9vu1cQeqPCCsS7mwNdPuYxg3b04eDJynHhC63kM8+ZsteOmiPElfVGOUmmKg==",
-      "dev": true
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -2141,21 +2022,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/recast": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
-      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
-      "dev": true,
-      "dependencies": {
-        "ast-types": "0.14.2",
-        "esprima": "~4.0.0",
-        "source-map": "~0.6.1",
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -2221,21 +2087,12 @@
       }
     },
     "node_modules/riot": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/riot/-/riot-7.0.3.tgz",
-      "integrity": "sha512-qufHMis10AooN5LNvjbKGT7dIM1GqrJqrV+3DGFUdCyAUBDGiVK6m4503/AJZRyJivNvZE0iMHSFqyT42LIpag==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/riot/-/riot-9.0.4.tgz",
+      "integrity": "sha512-oyS+7+sNpwJtu+AsL53NztBnYnkwFoiaXU4XD9Am+4pIgsUgnZl+uWN48V+7ti4w3dbgRm/JWFyJX46jwBUPfQ==",
       "dev": true,
-      "dependencies": {
-        "@riotjs/compiler": "^6.3.2",
-        "@riotjs/dom-bindings": "6.0.4",
-        "@riotjs/util": "^2.1.1",
-        "bianco.attr": "^1.1.1",
-        "bianco.query": "^1.1.4",
-        "cumpa": "^1.0.1",
-        "curri": "^1.0.1"
-      },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/rollup": {
@@ -2358,6 +2215,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2470,12 +2328,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2801,12 +2653,6 @@
     }
   },
   "dependencies": {
-    "@babel/parser": {
-      "version": "7.18.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
-      "integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
-      "dev": true
-    },
     "@eslint/eslintrc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -2883,57 +2729,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@riotjs/compiler": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@riotjs/compiler/-/compiler-6.3.2.tgz",
-      "integrity": "sha512-pGlLt08lhYeK+KMD3sPKsXInjQQWx9qMb7A/DPqbfMUvplsoTHnF2QfBWSmENqCaKGPGC4pTM1YCnaghQ5W6PA==",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "^7.18.10",
-        "@riotjs/parser": "^4.3.1",
-        "@riotjs/util": "2.1.1",
-        "cssesc": "^3.0.0",
-        "cumpa": "^1.0.1",
-        "curri": "^1.0.1",
-        "dom-nodes": "^1.1.3",
-        "globals": "^13.17.0",
-        "recast": "^0.20.5",
-        "source-map": "^0.7.4"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-          "dev": true
-        }
-      }
-    },
-    "@riotjs/dom-bindings": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@riotjs/dom-bindings/-/dom-bindings-6.0.4.tgz",
-      "integrity": "sha512-7KZh9dG8COmrW63xa27iAvN3Q0aJN3ACbXTg7YCuTtD2DGHdn1SmSheCYGn03pJUzsm1pdjS/mU4BFZ2tJQklQ==",
-      "dev": true,
-      "requires": {
-        "@riotjs/util": "^2.1.1"
-      }
-    },
-    "@riotjs/parser": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@riotjs/parser/-/parser-4.3.1.tgz",
-      "integrity": "sha512-ZUeAcey3ShAtquHBwuHFLrtPL1j0iEeXoOQoaZMaqVp15vq5UqOBxBcOVNfCXbr9ZbhnVCEEmek/9YFt5Ni8bA==",
-      "dev": true,
-      "requires": {
-        "curri": "^1.0.1",
-        "dom-nodes": "^1.1.3"
-      }
-    },
-    "@riotjs/util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@riotjs/util/-/util-2.1.1.tgz",
-      "integrity": "sha512-uE3yhckx6QhFESlA/jO/Nj8HcOeRiCV3Zw1OrdKiRAMh4o/JBhGuAkoknPWCDTHSFIffHuWV8EorbO1wZLBpvw==",
-      "dev": true
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -3052,15 +2847,6 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "ast-types": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
-      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.1"
-      }
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3072,15 +2858,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "bianco.attr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bianco.attr/-/bianco.attr-1.1.1.tgz",
-      "integrity": "sha512-fTjfPnnGYiCVbe5UltC/LsDRtJE+MjmadtL749CMIfCwjl18sdbCkaQ7cgtSao6iC9ZJC8Pzw0rjMdIuA6mK1g==",
-      "dev": true,
-      "requires": {
-        "bianco.dom-to-array": "^1.1.0"
-      }
     },
     "bianco.dom-to-array": {
       "version": "1.1.0",
@@ -3268,12 +3045,6 @@
         "which": "^2.0.1"
       }
     },
-    "cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true
-    },
     "cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -3296,18 +3067,6 @@
           "dev": true
         }
       }
-    },
-    "cumpa": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cumpa/-/cumpa-1.0.1.tgz",
-      "integrity": "sha512-Ew3sfG4cqvDFINS1VgdvLX1FIruhySlnP6DRLhB+1EjewiOzhJzKRKPEp/TCuo0RDisSFeuaDrk0S4Q8grF9CA==",
-      "dev": true
-    },
-    "curri": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/curri/-/curri-1.0.1.tgz",
-      "integrity": "sha512-VwFb2MGqN0A1RPA0vSgDRSWc0c+V6N9yz8pVYJ9AXILAukRAyCZP5Sqp4VdOxgw1lT0t5oaplwIDT/ruF3Nz7Q==",
-      "dev": true
     },
     "data-urls": {
       "version": "3.0.2",
@@ -3379,12 +3138,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "dom-nodes": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dom-nodes/-/dom-nodes-1.1.3.tgz",
-      "integrity": "sha512-y5wnIx97oe0IqMllL/lizgkK2c9vu1cQeqPCCsS7mwNdPuYxg3b04eDJynHhC63kM8+ZsteOmiPElfVGOUmmKg==",
-      "dev": true
     },
     "domexception": {
       "version": "4.0.0",
@@ -4425,18 +4178,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "recast": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
-      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
-      "dev": true,
-      "requires": {
-        "ast-types": "0.14.2",
-        "esprima": "~4.0.0",
-        "source-map": "~0.6.1",
-        "tslib": "^2.0.1"
-      }
-    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -4477,19 +4218,10 @@
       }
     },
     "riot": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/riot/-/riot-7.0.3.tgz",
-      "integrity": "sha512-qufHMis10AooN5LNvjbKGT7dIM1GqrJqrV+3DGFUdCyAUBDGiVK6m4503/AJZRyJivNvZE0iMHSFqyT42LIpag==",
-      "dev": true,
-      "requires": {
-        "@riotjs/compiler": "^6.3.2",
-        "@riotjs/dom-bindings": "6.0.4",
-        "@riotjs/util": "^2.1.1",
-        "bianco.attr": "^1.1.1",
-        "bianco.query": "^1.1.4",
-        "cumpa": "^1.0.1",
-        "curri": "^1.0.1"
-      }
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/riot/-/riot-9.0.4.tgz",
+      "integrity": "sha512-oyS+7+sNpwJtu+AsL53NztBnYnkwFoiaXU4XD9Am+4pIgsUgnZl+uWN48V+7ti4w3dbgRm/JWFyJX46jwBUPfQ==",
+      "dev": true
     },
     "rollup": {
       "version": "2.78.0",
@@ -4564,7 +4296,8 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "string-width": {
       "version": "4.2.2",
@@ -4649,12 +4382,6 @@
       "requires": {
         "punycode": "^2.1.1"
       }
-    },
-    "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "jsdom": "^20.0.0",
     "jsdom-global": "3.0.2",
     "mocha": "^8.4.0",
-    "riot": "^7.0.3",
+    "riot": "^9.0.4",
     "rollup": "^2.78.0"
   },
   "peerDependencies": {
-    "riot": "^6.0.0 || ^7.0.0"
+    "riot": "^6.0.0 || ^7.0.0 || ^9.0.0"
   },
   "homepage": "https://github.com/riot/hot-reload#readme",
   "license": "MIT",


### PR DESCRIPTION
Just like in https://github.com/riot/hot-reload/issues/18 and https://github.com/riot/hot-reload/commit/d015d5715e7af626d165467725226beb2a263a75 to make this (hopefully) working without warnings with riot 9.x.

By the way, just an idea to refactor this whole library: you could remove the `rollup` building and add `"type": "module"` to package.json, then you can directly use `src/index.js` as entrypoint and improve importing in projects with `import reload from '@riotjs/hot-reload'` - this would make it more clean.